### PR TITLE
Add minimal POC website based off of stlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .venv/
 test-videos/out-*.mp4
 __pycache__/
+node_modules/

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>Serverless Image Processing App</title>
+    <meta
+      name="description"
+      content="A Serverless Streamlit application with OpenCV image processing that completely works on your browser"
+    />
+    <link
+      rel="stylesheet"
+      href="./node_modules/@stlite/mountable/build/stlite.css"
+    />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script src="./node_modules/@stlite/mountable/build/stlite.js"></script>
+    <script>
+      async function main() {
+        stlite.mount(
+          {
+            requirements: ["opencv-python"],
+            files: {
+              "web.py": await fetch("web.py").then((res) => res.text()),
+            },
+            entrypoint: "web.py",
+          },
+          document.getElementById("root")
+        );
+      }
+      main();
+    </script>
+  </body>
+</html>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "bart-web",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bart-web",
+      "version": "0.0.1",
+      "dependencies": {
+        "@stlite/mountable": "^0.42.3"
+      }
+    },
+    "node_modules/@stlite/mountable": {
+      "version": "0.42.3",
+      "resolved": "https://registry.npmjs.org/@stlite/mountable/-/mountable-0.42.3.tgz",
+      "integrity": "sha512-lTHJU80DMcQwlMSig+8UCMirNoYI1oWd9D3uLKiPqyGoAGGYszy56NnQ2KTr9KTUyR+KGheL+EZxJR6LxVjH3w=="
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "bart-web",
+  "version": "0.0.1",
+  "scripts": {
+    "start": "npx http-server"
+  },
+  "dependencies": {
+    "@stlite/mountable": "^0.42.3"
+  }
+}

--- a/web/web.py
+++ b/web/web.py
@@ -1,0 +1,96 @@
+import io
+
+import cv2
+import numpy as np
+import streamlit as st
+
+bytes_data = None
+
+st.subheader("Input")
+input_mode = st.radio("Input mode", ["Camera", "File upload"])
+
+if input_mode == "Camera":
+    img_file_buffer = st.camera_input("Take a picture")
+
+    if img_file_buffer is not None:
+        bytes_data = img_file_buffer.getvalue()
+else:
+    uploaded_file = st.file_uploader("Choose an image file", type=["png", "jpg"])
+    if uploaded_file is not None:
+        # To read file as bytes:
+        bytes_data = uploaded_file.getvalue()
+
+if bytes_data is None:
+    st.stop()
+
+img = cv2.imdecode(np.frombuffer(bytes_data, np.uint8), cv2.IMREAD_COLOR)
+img_bgr = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+orig_img = img
+
+if input_mode != "Camera":
+    st.image(img_bgr)
+st.text(f"({img.shape[1]}x{img.shape[0]})")
+
+st.header("Image transform")
+
+with st.sidebar:
+    st.subheader("Flip")
+    v_flip = st.checkbox("Vertically")
+    h_flip = st.checkbox("Horizontally")
+    if v_flip:
+        img = img[::-1, :, :]
+    if h_flip:
+        img = img[:, ::-1, :]
+
+    st.subheader("Blur filter")
+    blur_mode = st.radio(
+        "Blur mode", ("None", "Averaging", "Gaussian", "Median", "Bilateral")
+    )
+    st.markdown(
+        "See https://docs.opencv.org/4.x/d4/d13/tutorial_py_filtering.html for the details"
+    )
+    if blur_mode == "Averaging":
+        ksize = st.slider("Kernel size", 1, 100, value=10)
+        img = cv2.blur(img, (ksize, ksize))
+    elif blur_mode == "Gaussian":
+        ksize = st.slider("Kernel size", 1, 100, value=11, step=2)
+        sigma = st.slider("Sigma", 0, 10, value=0)
+        img = cv2.GaussianBlur(img, (ksize, ksize), sigma)
+    elif blur_mode == "Median":
+        ksize = st.slider("Kernel size", 1, 100, value=11, step=2)
+        img = cv2.medianBlur(img, ksize)
+    elif blur_mode == "Bilateral":
+        d = st.slider("d", 1, 30, value=9)
+        sigma_color = st.slider("Sigma color", 1, 100, value=75)
+        sigma_space = st.slider("Sigma space", 1, 100, value=75)
+        img = cv2.bilateralFilter(img, d, sigma_color, sigma_space)
+
+    st.subheader("Resize")
+    orig_height, orig_width = img.shape[:2]
+    target_width = st.slider("Width", 16, orig_width, step=1, value=orig_width)
+    keep_aspect_ratio = st.checkbox("Keep aspect ratio", value=True)
+    if keep_aspect_ratio:
+        target_height = orig_height * target_width // orig_width
+    else:
+        target_height = st.slider("Height", 16, orig_height, step=1, value=orig_height)
+    img = cv2.resize(img, (target_width, target_height))  # TODO: Interpolation option
+
+    st.subheader("Encode")
+    encode_type = st.radio("Encode type", ("PNG", "JPEG"))
+    if encode_type == "PNG":
+        ret, encoded = cv2.imencode(".png", img)
+    else:
+        jpeg_quality = st.slider("JPEG quality", 0, 100, value=90)
+        ret, encoded = cv2.imencode(
+            ".jpg", img, (cv2.IMWRITE_JPEG_QUALITY, jpeg_quality)
+        )
+
+if ret:
+    st.subheader("Output")
+    encoded_bytes_data = io.BytesIO(encoded)
+    st.image(encoded_bytes_data)
+    st.text(f"({target_width}x{target_height})")
+
+    st.download_button(
+        "Download", encoded_bytes_data, file_name=f"processed.{encode_type.lower()}"
+    )


### PR DESCRIPTION
Esto agrega un muy sencillo procesador de imagenes robado de https://github.com/whitphx/stlite-image-processing-app. 

![image](https://github.com/bart-ai/bart/assets/25667102/65a59b4a-d331-4e97-8ce2-45504399fa23)

Partiendo de la idea de que queremos correr esto sobre WASM, empece buscando como compilar Python a WASM. El proyecto indicado para esto es [Pyodide](https://github.com/pyodide/pyodide). El tema es que es muy low-level para el scope de bart (debatible...), así que busqué algo que construya arriba de eso. 

Eventualmente encontré [stlite](https://github.com/whitphx/stlite) ([charla](https://youtu.be/fYB5hhM7P8k)): un proyecto que portea [streamlit](https://streamlit.io/) (un framework de python server-side) a WASM, gracias a Pyodide, dandonos así una manera de tener páginas web serverless que interactuen con el usuario.

La idea es que vos escribis tu página de streamlit (que se puede correr con `pip install streamlit` + `streamlit run web.py`) y después con el index.html y stlite, montas ese archivo .py en el browser.

Entonces, ahora, con `npm install` se instala `stlite` como dependencia, y con `npm start` se levanta un servidor de node mínimo que corre el archivo, dandonos una página que usa la webcam del usuario en el código de python.

